### PR TITLE
Support for internationalized domain names

### DIFF
--- a/src/api.php
+++ b/src/api.php
@@ -9,6 +9,9 @@ list($domain, $port) = filter_domain($_GET["domain"]);
 // Check the site and get the response code.
 $data = get_response($domain, $port);
 
+// Check if IDN domain - convert, display correct domain name in HTML
+$domain = convert_idn_domain($domain);
+
 // Split the code and data into seperate vars.
 $code = $data["code"];
 

--- a/src/check.php
+++ b/src/check.php
@@ -9,6 +9,9 @@ list($domain, $port) = filter_domain($_GET["domain"]);
 // Check the site and get the response code.
 $data = get_response($domain, $port);
 
+// Check if IDN domain - convert, display correct domain name in HTML
+$domain = convert_idn_domain($domain);
+
 // Caluate and format the time taken to connect.
 $time = round($data["time"], 3);
 


### PR DESCRIPTION
Hi @sjparkinson !

I'm addressing an issue raised in the DuckDuckGo [instant answer repository](https://github.com/duckduckgo/zeroclickinfo-spice/)

>IsItUp - Fails on domains with unicode characters

[Issue 220](https://github.com/duckduckgo/zeroclickinfo-spice/issues/220)

This PR adds support for [Internationalized domain name](https://en.wikipedia.org/wiki/Internationalized_domain_name) (eg. `académie-française.fr`)

#### Before
![2016-01-05-56-oh no acadmie-franaise fr is down __ isitup org](https://cloud.githubusercontent.com/assets/5282264/12117464/e2bf7ae2-b3fb-11e5-83bc-da1a91d0cec8.png)


#### After
![2016-01-05-30-yay academie-francaise fr is up __ isitup org](https://cloud.githubusercontent.com/assets/5282264/12117467/e42e70fe-b3fb-11e5-8620-a328bbac8ed1.png)

**Please let me know if there's any issues with my implementation and I'll be happy to update.**

**Updates**
+ Add convert_idn_domain function.
+ Update check.php and api.php to call convert_idn_domain function.
+ Update gen_json call to json_encode to include JSON_UNESCAPED_UNICODE