### PR TITLE
Add 308 redirect

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -157,7 +157,7 @@ function get_response($domain, $port)
  */
 function gen_id($data)
 {
-    $good_codes = array(200, 301, 302, 303, 304, 307, 400, 401, 403, 405);
+    $good_codes = array(200, 301, 302, 303, 304, 307, 308, 400, 401, 403, 405);
 
     if ($data["valid"] === false)
     {


### PR DESCRIPTION
This PR adds a 308 redirect as a valid status code.

However, I believe the logic is wrong.

Instead checking for valid status codes, you should check for invalid status codes that indicate server error (500-599) or not found (404). 

https://developer.mozilla.org/en-US/docs/Web/HTTP/Status