### PR TITLE
Migrate to GitHub Container Registry

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -19,7 +19,7 @@ jobs:
             const deployment = await github.repos.createDeployment({
               ...context.repo,
               ref: '${{ github.sha }}',
-              environment: 'production',
+              environment: 'Production',
               required_contexts: [],
               mediaType: { previews: ['flash', 'ant-man'] }
             })
@@ -39,18 +39,19 @@ jobs:
             })
 
       - name: docker login
-        run: docker login docker.pkg.github.com --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }}
+        run: docker login ghcr.io --username ${{ github.actor }} --password ${{ secrets.GH_CONTAINER_REGISTRY_TOKEN }}
 
       - name: docker build
         run: |
           docker build . \
-            -t docker.pkg.github.com/${{ github.repository }}/isitup.org:${{ github.sha }} \
-            -t docker.pkg.github.com/${{ github.repository }}/isitup.org:latest
+            --cache-from ghcr.io/${{ github.repository }}/isitup.org:latest \
+            -t ghcr.io/${{ github.repository }}:${{ github.sha }} \
+            -t ghcr.io/${{ github.repository }}:latest
 
       - name: docker push
         run: |
-          docker push docker.pkg.github.com/${{ github.repository }}/isitup.org:${{ github.sha }}
-          docker push docker.pkg.github.com/${{ github.repository }}/isitup.org:latest
+          docker push ghcr.io/${{ github.repository }}:${{ github.sha }}
+          docker push ghcr.io/${{ github.repository }}:latest
 
       - name: install doctl
         uses: digitalocean/action-doctl@v2
@@ -79,7 +80,7 @@ jobs:
               spec:
                 containers:
                   - name: isitup-org
-                    image: docker.pkg.github.com/${{ github.repository }}/isitup.org:${{ github.sha }}
+                    image: ghcr.io/${{ github.repository }}:${{ github.sha }}
           EOF
 
       - name: kubectl apply

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -29,7 +29,7 @@ spec:
                 topologyKey: kubernetes.io/hostname
       containers:
         - name: isitup-org
-          image: docker.pkg.github.com/sjparkinson/isitup.org/isitup.org:latest
+          image: ghcr.io/sjparkinson/isitup.org:latest
           ports:
             - containerPort: 80
           resources:
@@ -52,4 +52,4 @@ spec:
             initialDelaySeconds: 3
             timeoutSeconds: 3
       imagePullSecrets:
-        - name: github
+        - name: github-container-registry


### PR DESCRIPTION
Following the instructions at https://docs.github.com/en/packages/guides/migrating-to-github-container-registry-for-docker-images.